### PR TITLE
Minor: Update link to redirect to rose-pine/discord

### DIFF
--- a/rose-pine.theme.css
+++ b/rose-pine.theme.css
@@ -4,8 +4,8 @@
 * @authorId 403390454273409028
 * @version 3.0.9
 * @description All natural pine, faux fur and a bit of soho vibes for the classy minimalist.
-* @source https://github.com/blueb442/discord
-* @updateUrl https://github.com/blueb442/discord/blob/rose-pine.theme.css
+* @source https://github.com/rose-pine/discord
+* @updateUrl https://github.com/rose-pine/discord/blob/rose-pine.theme.css
 */
 
 @import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;500;600;700&display=swap');


### PR DESCRIPTION
Currently the metainfo will redirect to https://github.com/blueb442/discord which is no longer valid. I'm assuming it would also prevent the theme from checking for updates as well. 