### PR TITLE
CSS additions for Discord Forums UI

### DIFF
--- a/rose-pine.theme.css
+++ b/rose-pine.theme.css
@@ -105,3 +105,11 @@ body {
 .layout-1qmrhw:hover, .content-1gYQeQ:hover {
     background-color: var(--background-modifier-selected)!important;
 }
+
+.container-3wLKDe {
+    background-color: var(--background-secondary) !important;
+}
+
+.title-31SJ6t {
+    background-color: var(--background-primary) !important;
+}


### PR DESCRIPTION
updated Discord's Forum UI elements to use appropriate rose pine colors. Not sure if this is correct, but seemed to make sense.

BEFORE:
![Before](https://github.com/rose-pine/discord/assets/76633125/132cb60c-b48e-433e-b7b9-bd5d1cf90830)

AFTER:
![After](https://github.com/rose-pine/discord/assets/76633125/0ff1bb7d-8786-48e3-aa1d-4765a30cd2ee)
