### PR TITLE
Use the `Chat-Font` variable across all class

### DIFF
--- a/rose-pine.theme.css
+++ b/rose-pine.theme.css
@@ -13,7 +13,9 @@
 --Chat-Font-Used: 'Fira Code', monospace ;
 --Chat-Font-Size: 14px;
 
+    --font-primary: --Chat-Font-Used;
     --font-display: --Chat-Font-Used;
+    --font-code: --Chat-Font-Used;
 }
 
 .theme-dark {

--- a/rose-pine.theme.css
+++ b/rose-pine.theme.css
@@ -10,7 +10,7 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@300..700&display=swap');
 :root {
---Chat-Font-Used: 'Fira Code', normal ;
+--Chat-Font-Used: 'Fira Code', monospace ;
 --Chat-Font-Size: 14px;
 
     --font-display: --Chat-Font-Used;

--- a/rose-pine.theme.css
+++ b/rose-pine.theme.css
@@ -12,9 +12,8 @@
 :root {
 --Chat-Font-Used: 'Fira Code', normal ;
 --Chat-Font-Size: 14px;
-}
-:not([class="hljs"]):not(code){
-font-family: var(--Chat-Font-Used)!important;
+
+    --font-display: --Chat-Font-Used;
 }
 
 .theme-dark {

--- a/rose-pine.theme.css
+++ b/rose-pine.theme.css
@@ -63,10 +63,6 @@ font-family: var(--Chat-Font-Used)!important;
     --interactive-active: #575279;
 }
 
-body {
-    --font-display: Fira Code;
-}
-
 .body-2wLx-E, .headerTop-3GPUSF, .bodyInnerWrapper-2bQs1k, .footer-3naVBw {
     background-color: var(--background-tertiary);
 }
@@ -80,7 +76,6 @@ body {
 }
 
 .username-h_Y3Us {
-    font-family: var(--font-display);
     font-size: 14px;
 }
 

--- a/rose-pine.theme.css
+++ b/rose-pine.theme.css
@@ -67,7 +67,7 @@
 }
 
 .title-17SveM, .name-3Uvkvr{
-    font-size: 14px;
+    font-size: var(--Chat-Font-Size);
 }
 
 .panels-3wFtMD {
@@ -75,7 +75,7 @@
 }
 
 .username-h_Y3Us {
-    font-size: 14px;
+    font-size: var(--Chat-Font-Size);
 }
 
 .peopleColumn-1wMU14, .panels-j1Uci_, .peopleColumn-29fq28, .peopleList-2VBrVI, .content-2hZxGK, .header-1zd7se, .root-g14mjS .small-23Atuv .fullscreenOnMobile-ixj0e3{

--- a/rose-pine.theme.css
+++ b/rose-pine.theme.css
@@ -8,7 +8,7 @@
 * @updateUrl https://github.com/rose-pine/discord/blob/rose-pine.theme.css
 */
 
-@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@300..700&display=swap');
 :root {
 --Chat-Font-Used: 'Fira Code', normal ;
 --Chat-Font-Size: 14px;


### PR DESCRIPTION
Fixes the placeholder text on empty input field, noticeable when editing server profile; and uses the font on code blocks.
Uses the previously unused `Chat-Font-Size` variable.

Replaced the original CSS selector by overriding base `:root`'s `--font-*` variables provided by Discord.

Uses the Fira Code Variable (I don't know why I actually commit this one, probably because it feels more modern).

<details>

<summary>
Tested on latest Discord client
</summary>

```
stable 279382 (5c40119) Host 1.0.9038 x86 (45524) Windows 11 64-bit (10.0.22631)
```

</details>