### PR TITLE
fix: remove corner text from variant themes

### DIFF
--- a/dist/rose-pine-dawn.css
+++ b/dist/rose-pine-dawn.css
@@ -12,10 +12,9 @@ CONFIGURATION 📝‼️
 */
 
 :root {
-
     /* 1=False ; 0=True */
     --windows-hover: 1;
-
+    
     --base: #faf4ed;
     --surface: #fffaf3;
     --overlay: #f2e9e1;
@@ -90,11 +89,6 @@ CONFIGURATION 📝‼️
     cursor: default;
 
 }
-
-.trailing_c38106 {
-    padding-right: 10px !important;
-}
-
 .trailing_c38106 {
     padding-right: 10px !important;
 }
@@ -270,7 +264,6 @@ CONFIGURATION 📝‼️
 .channelInfo_c69b6d {
     color: var(--foam) !important;
 }
-
 
 /* Make Read Channel Names duller */
 .wrapper__2ea32:not(.modeUnreadImportant__2ea32) .name__2ea32 {

--- a/dist/rose-pine-dawn.css
+++ b/dist/rose-pine-dawn.css
@@ -48,23 +48,6 @@ CONFIGURATION 📝‼️
     /* Hide the original SVG */
 }
 
-/* Top left custom text */
-.container_c48ade::before {
-    content: "Rosé Pine";
-    position: absolute;
-    top: 10px;
-    left: 16px;
-    color: #ffffff77;
-    font-size: 14px;
-    font-weight: bold;
-    font-family: var(--font-primary);
-    z-index: 9999;
-    pointer-events: none;
-    opacity: 0.9;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
-
-}
-
 .wrapper__6e9f8[aria-label="Direct Messages"] .childWrapper__6e9f8 {
     display: flex;
     /* Ensure proper layout */

--- a/dist/rose-pine-moon.css
+++ b/dist/rose-pine-moon.css
@@ -11,11 +11,10 @@
 CONFIGURATION 📝‼️
 */
 
-
 :root {
     /* 1=False ; 0=True */
     --windows-hover: 1;
-
+    
     --base: #232136;
     --surface: #2a273f;
     --overlay: #393552;
@@ -266,7 +265,6 @@ CONFIGURATION 📝‼️
     color: var(--foam) !important;
 }
 
-
 /* Make Read Channel Names duller */
 .wrapper__2ea32:not(.modeUnreadImportant__2ea32) .name__2ea32 {
     /* color: var(--muted) !important; */
@@ -465,7 +463,6 @@ path.unreadPillCapStroke__908e2 {
 .iconWrapper__9293f.clickable__9293f[aria-label="Close"] path {
     fill: var(--love) !important;
 }
-
 
 /* Code Blocks */
 .codeContainer__75297 {
@@ -1057,7 +1054,6 @@ button[aria-label="User Settings"] .lottieIcon__5eb9b svg path {
     background-color: var(--surface) !important;
 }
 
-
 .top_b3f026 .item_b3f026.brand_b3f026 {
     background-color: transparent !important;
 }
@@ -1109,7 +1105,6 @@ button[aria-label="User Settings"] .lottieIcon__5eb9b svg path {
     background-color: var(--highlightLow) !important;
     border-radius: 15px !important;
 }
-
 
 
 

--- a/dist/rose-pine-moon.css
+++ b/dist/rose-pine-moon.css
@@ -48,23 +48,6 @@ CONFIGURATION 📝‼️
     /* Hide the original SVG */
 }
 
-/* Top left custom text */
-.container_c48ade::before {
-    content: "Rosé Pine";
-    position: absolute;
-    top: 10px;
-    left: 16px;
-    color: #ffffff77;
-    font-size: 14px;
-    font-weight: bold;
-    font-family: var(--font-primary);
-    z-index: 9999;
-    pointer-events: none;
-    opacity: 0.9;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
-
-}
-
 .wrapper__6e9f8[aria-label="Direct Messages"] .childWrapper__6e9f8 {
     display: flex;
     /* Ensure proper layout */

--- a/dist/rose-pine.css
+++ b/dist/rose-pine.css
@@ -14,7 +14,7 @@ CONFIGURATION 📝‼️
 :root {
     /* 1=False ; 0=True */
     --windows-hover: 1;
-
+    
     --base: #191724;
     --surface: #1f1d2e;
     --overlay: #26233a;
@@ -45,23 +45,6 @@ CONFIGURATION 📝‼️
 .wrapper__6e9f8[aria-label="Direct Messages"] .childWrapper__6e9f8 svg {
     display: none;
     /* Hide the original SVG */
-}
-
-/* Top left custom text */
-.container_c48ade::before {
-    content: "Rosé Pine";
-    position: absolute;
-    top: 10px;
-    left: 16px;
-    color: #ffffff77;
-    font-size: 14px;
-    font-weight: bold;
-    font-family: var(--font-primary);
-    z-index: 9999;
-    pointer-events: none;
-    opacity: 0.9;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
-
 }
 
 .wrapper__6e9f8[aria-label="Direct Messages"] .childWrapper__6e9f8 {

--- a/template.theme.css
+++ b/template.theme.css
@@ -47,23 +47,6 @@ CONFIGURATION 📝‼️
     /* Hide the original SVG */
 }
 
-/* Top left custom text */
-.container_c48ade::before {
-    content: "Rosé Pine";
-    position: absolute;
-    top: 10px;
-    left: 16px;
-    color: #ffffff77;
-    font-size: 14px;
-    font-weight: bold;
-    font-family: var(--font-primary);
-    z-index: 9999;
-    pointer-events: none;
-    opacity: 0.9;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
-
-}
-
 .wrapper__6e9f8[aria-label="Direct Messages"] .childWrapper__6e9f8 {
     display: flex;
     /* Ensure proper layout */


### PR DESCRIPTION
Little tweak to prevent overlapping with control buttons for the desktop environments favoring that corner. :)

<img width="186" height="174" alt="image" src="https://github.com/user-attachments/assets/1c051b65-f38b-4d4e-9cd7-45a1b438ad58" />
